### PR TITLE
Improve performance and add image meta tags

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -4,7 +4,9 @@
 		<meta name="viewport" content="width=device-width">
 		<meta property="og:image" content="https://raw.githubusercontent.com/fregante/GhostText/main/promo/demo-screen.png">
 		<link rel="preconnect" href="https://fonts.gstatic.com">
-		<link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Roboto&family=Roboto+Slab:wght@300&display=swap">
+		<!-- https://css-tricks.com/the-fastest-google-fonts/ -->
+		<link rel="preload" href="https://fonts.googleapis.com/css2?family=Roboto&family=Roboto+Slab:wght@300&display=swap" as="style">
+		<link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Roboto&family=Roboto+Slab:wght@300&display=swap" media="print" onload="this.media='all'">
 		<link rel="stylesheet" href="/style.css">
 		<title>{{ page.title }}</title>
 	</head>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -14,7 +14,7 @@
 		<main>
 			<h1>
 				<a href="/">
-					<img src="https://raw.githubusercontent.com/fregante/GhostText/main/promo/gt_banner.png" alt="GhostText">
+					<img src="https://raw.githubusercontent.com/fregante/GhostText/main/promo/gt_banner.png" alt="GhostText" width="936" height="266">
 					<span hidden>•</span>
 					Use your text editor
 					<span class="d-inline-block">in the browser</span>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -2,8 +2,9 @@
 	<head>
 		<meta charset="utf-8">
 		<meta name="viewport" content="width=device-width">
+		<meta property="og:image" content="https://raw.githubusercontent.com/fregante/GhostText/main/promo/demo-screen.png">
 		<link rel="preconnect" href="https://fonts.gstatic.com">
-		<link href="https://fonts.googleapis.com/css2?family=Roboto&family=Roboto+Slab:wght@300&display=swap" rel="stylesheet">
+		<link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Roboto&family=Roboto+Slab:wght@300&display=swap">
 		<link rel="stylesheet" href="/style.css">
 		<title>{{ page.title }}</title>
 	</head>

--- a/index.html
+++ b/index.html
@@ -18,27 +18,27 @@ footer: |
 <ul class="apps">
 	<li>
 		<a target="_blank" href="https://chrome.google.com/webstore/detail/refined-github/godiecgffnchndlihlpaajjcplehddca">
-			<img src="https://raw.githubusercontent.com/alrra/browser-logos/main/src/chrome/chrome_128x128.png" width="48" alt="Chrome">
+			<img src="https://raw.githubusercontent.com/alrra/browser-logos/main/src/chrome/chrome_128x128.png" width="48" height="48" alt="Chrome">
 		</a>
 	</li>
 	<li>
 		<a target="_blank" href="https://addons.mozilla.org/en-US/firefox/addon/ghosttext/">
-			<img src="https://raw.githubusercontent.com/alrra/browser-logos/main/src/firefox/firefox_128x128.png" width="48" alt="Firefox">
+			<img src="https://raw.githubusercontent.com/alrra/browser-logos/main/src/firefox/firefox_128x128.png" width="48" height="48" alt="Firefox">
 		</a>
 	</li>
 	<li>
 		<a target="_blank" href="https://apps.apple.com/app/ghosttext/id1552641506">
-			<img src="https://raw.githubusercontent.com/alrra/browser-logos/main/src/safari/safari_128x128.png" width="48" alt="Safari">
+			<img src="https://raw.githubusercontent.com/alrra/browser-logos/main/src/safari/safari_128x128.png" width="48" height="48" alt="Safari">
 		</a>
 	</li>
 	<li>
 		<a target="_blank" href="https://chrome.google.com/webstore/detail/refined-github/godiecgffnchndlihlpaajjcplehddca">
-			<img src="https://raw.githubusercontent.com/alrra/browser-logos/main/src/edge/edge_128x128.png" width="48" alt="Edge">
+			<img src="https://raw.githubusercontent.com/alrra/browser-logos/main/src/edge/edge_128x128.png" width="48" height="48" alt="Edge">
 		</a>
 	</li>
 	<li>
 		<a target="_blank" href="https://chrome.google.com/webstore/detail/refined-github/godiecgffnchndlihlpaajjcplehddca">
-			<img src="https://raw.githubusercontent.com/alrra/browser-logos/main/src/opera/opera_128x128.png" width="48" alt="Opera">
+			<img src="https://raw.githubusercontent.com/alrra/browser-logos/main/src/opera/opera_128x128.png" width="48" height="48" alt="Opera">
 		</a>
 	</li>
 </ul>

--- a/style.css
+++ b/style.css
@@ -170,6 +170,6 @@ footer {
 
 footer.fregante {
 	background: #2c5700;
-	padding-top: 40px;
-	padding-bottom: 40px;
+	padding-top: 50px;
+	padding-bottom: 50px;
 }


### PR DESCRIPTION
Page score: 79

<img width="744" alt="Screen Shot" src="https://user-images.githubusercontent.com/1402241/108584833-03781280-730a-11eb-8bad-35ce27395c06.png">


The next best improvements will be:

- moving all of the images locally, sizing them correctly
- replacing the gif with a custom animation